### PR TITLE
more info: GET /api/uses/X when sso admin or self

### DIFF
--- a/apidoc/swagger.json
+++ b/apidoc/swagger.json
@@ -87,6 +87,7 @@
             ],
             "get": {
                 "summary": "获取用户信息",
+                "description": "如果传入 sso 管理员或者本人的认证信息，可以得到 mobile 和 email，否则仅仅拿到用户公开的信息",
                 "responses": {
                     "200": {
                         "description": "用户信息",

--- a/ssolib/user.go
+++ b/ssolib/user.go
@@ -181,7 +181,9 @@ func (ur UserResource) Delete(ctx context.Context, r *http.Request) (int, interf
 
 		err = ub.DeleteUser(u)
 		if err != nil {
-			panic(err)
+			// since some backend delete user means delete user from group
+			log.Debug(err)
+			return http.StatusNoContent, "User deleted from groups but " + err.Error()
 		}
 
 		return http.StatusNoContent, "User deleted"


### PR DESCRIPTION
如果传入 sso 管理员或者本人的认证信息，可以得到 mobile 和 email，否则仅仅拿到用户公开的信息